### PR TITLE
Remove create_before_destroy on node pools

### DIFF
--- a/terraform/_modules/cluster/cluster.tf
+++ b/terraform/_modules/cluster/cluster.tf
@@ -82,10 +82,6 @@ resource "google_container_node_pool" "core" {
         service_account = "${var.service_account_email}"
         oauth_scopes    = "${concat(var.basic_gke_oauth_scopes, var.core_node_pool_extra_scopes)}"
     }
-
-    lifecycle {
-        create_before_destroy = true
-    }
 }
 
 
@@ -101,10 +97,6 @@ resource "google_container_node_pool" "worker" {
         preemptible     = true
         service_account = "${var.service_account_email}"
         oauth_scopes    = "${var.basic_gke_oauth_scopes}"
-    }
-
-    lifecycle {
-        create_before_destroy = true
     }
 }
 


### PR DESCRIPTION
Because we can't have node pools with duplicate names.