### PR TITLE
Bump to GKE 1.7.8 because that actually exists

### DIFF
--- a/terraform/env/_modules/cluster/cluster.tf
+++ b/terraform/env/_modules/cluster/cluster.tf
@@ -56,7 +56,7 @@ resource "google_container_cluster" "cluster" {
     zone                = "${var.zones[0]}"
     name                = "${var.name}"
 
-    node_version        = "1.7.6" # TODO - note the current "-gke.1" weirdness in https://github.com/terraform-providers/terraform-provider-google/issues/492
+    node_version        = "1.7.8"
 
     lifecycle {
         ignore_changes  = ["node_pools"]

--- a/terraform/env/_modules/env/env.tf
+++ b/terraform/env/_modules/env/env.tf
@@ -5,7 +5,6 @@ variable "project_name"                 {}
 variable "project_id_prefix"            {}
 variable "viewer_group"                 {}
 variable "container_developer_group"    {}
-variable "container_full_access"        {}
 variable "domain_name"                  {}
 variable "dns_ttl"                      {}
 variable "cluster_name"                 {}
@@ -13,6 +12,7 @@ variable "cluster_core_node_type"       {}
 variable "cluster_core_node_count"      {}
 variable "cluster_worker_node_type"     {}
 variable "cluster_worker_node_count"    {}
+variable "cluster_full_access"          {}
 
 
 data "terraform_remote_state" "global" {
@@ -52,7 +52,7 @@ module "iam" {
     project_id                  = "${module.project.id}"
     global_project_id           = "${data.terraform_remote_state.global.project_id}"
     viewer_member               = "group:${var.viewer_group}"
-    container_full_access       = "${var.container_full_access}"
+    cluster_full_access         = "${var.cluster_full_access}"
     container_developer_members = [
         "group:${var.container_developer_group}",
         "serviceAccount:${data.terraform_remote_state.global.circleci_service_account_email}",  // In order to deploy website

--- a/terraform/env/_modules/iam/iam.tf
+++ b/terraform/env/_modules/iam/iam.tf
@@ -1,7 +1,7 @@
 variable "project_id"                       {}
 variable "global_project_id"                {}
 variable "viewer_member"                    {}
-variable "container_full_access"            {}
+variable "cluster_full_access"              {}
 variable "container_developer_members"      { type = "list" }
 
 
@@ -20,7 +20,7 @@ resource "google_project_iam_member" "viewer" {
 resource "google_project_iam_member" "container_developer" {
     count               = "${length(var.container_developer_members)}"
     project             = "${var.project_id}"
-    role                = "roles/${var.container_full_access ? "container.clusterAdmin" : "container.developer"}"
+    role                = "roles/${var.cluster_full_access ? "container.clusterAdmin" : "container.developer"}"
     member              = "${element(var.container_developer_members, count.index)}"
 }
 

--- a/terraform/env/dev.tfvars
+++ b/terraform/env/dev.tfvars
@@ -9,6 +9,6 @@ cluster_core_node_type      = "n1-standard-2"
 cluster_core_node_count     = 1
 cluster_worker_node_type    = "n1-standard-1"
 cluster_worker_node_count   = 1
+cluster_full_access         = true
 
-container_full_access       = true
 container_developer_group   = "core@quartic.io"

--- a/terraform/env/main.tf
+++ b/terraform/env/main.tf
@@ -5,7 +5,6 @@ variable "project_name"                 {}
 variable "project_id_prefix"            {}
 variable "viewer_group"                 {}
 variable "container_developer_group"    {}
-variable "container_full_access"        { default=false }
 variable "domain_name"                  {}
 variable "dns_ttl"                      {}
 variable "cluster_name"                 {}
@@ -13,6 +12,7 @@ variable "cluster_core_node_type"       {}
 variable "cluster_core_node_count"      {}
 variable "cluster_worker_node_type"     {}
 variable "cluster_worker_node_count"    {}
+variable "cluster_full_access"          { default=false }
 
 
 terraform {
@@ -37,7 +37,6 @@ module "env" {
     project_id_prefix           = "${var.project_id_prefix}"
     viewer_group                = "${var.viewer_group}"
     container_developer_group   = "${var.container_developer_group}"
-    container_full_access       = "${var.container_full_access}"
     domain_name                 = "${var.domain_name}"
     dns_ttl                     = "${var.dns_ttl}"
     cluster_name                = "${var.cluster_name}"
@@ -45,6 +44,7 @@ module "env" {
     cluster_core_node_count     = "${var.cluster_core_node_count}"
     cluster_worker_node_type    = "${var.cluster_worker_node_type}"
     cluster_worker_node_count   = "${var.cluster_worker_node_count}"
+    cluster_full_access         = "${var.cluster_full_access}"
 }
 
 


### PR DESCRIPTION
There was some freakout with version naming on GKE.  It's now been fixed, but we should use 1.7.8 as a result.

#### Unrelated changes

Have also renamed a param for consistency.